### PR TITLE
Add support for Teensy 4.x

### DIFF
--- a/src/SSLClientParameters.cpp
+++ b/src/SSLClientParameters.cpp
@@ -1,7 +1,7 @@
 #include "SSLClientParameters.h"
 
-// fix for non-exception arduino platforms
-#ifdef ADAFRUIT_FEATHER_M0
+// fix for non-exception arduino platforms (Feather and Teensy 4.0)
+#if defined ADAFRUIT_FEATHER_M0 || defined __IMXRT1062__
 namespace std {
     void __throw_length_error(char const*) {}
 }


### PR DESCRIPTION
Teensy 4.x doesn't support exidx calls (yet), this fixes support for Teensy 4.x.