### PR TITLE
M_IOBUF size definable from the constructor (backward compatible)

### DIFF
--- a/src/SSLClient.h
+++ b/src/SSLClient.h
@@ -98,7 +98,14 @@ public:
                         const size_t trust_anchors_num, 
                         const int analog_pin, 
                         const size_t max_sessions = 1,
+                        const size_t buffer_size = 2048, 
                         const DebugLevel debug = SSL_WARN);
+
+    /**
+     * @brief Destructor
+     * Frees the dynamically allocated m_iobuf.
+     */
+    ~SSLClient();
 
     //========================================
     //= Functions implemented in SSLClient.cpp
@@ -466,7 +473,8 @@ private:
      * As a rule of thumb SSLClient will fail if it does not have at least 8000 bytes when starting a
      * connection.
      */
-    unsigned char m_iobuf[2048];
+    unsigned char* m_iobuf;
+    size_t m_iobuf_size;
     // store the index of where we are writing in the buffer
     // so we can send our records all at once to prevent
     // weird timing issues

--- a/src/SSLClient.h
+++ b/src/SSLClient.h
@@ -91,6 +91,7 @@ public:
      * @param trust_anchors_num The number of objects in the trust_anchors array.
      * @param analog_pin An analog pin to pull random bytes from, used in seeding the RNG.
      * @param max_sessions The maximum number of SSL sessions to store connection information from.
+     * @param buffer_size The size of the buffer used for SSL communication.
      * @param debug The level of debug logging (use the ::DebugLevel enum).
      */
     explicit SSLClient( Client& client, 
@@ -100,6 +101,24 @@ public:
                         const size_t max_sessions = 1,
                         const size_t buffer_size = 2048, 
                         const DebugLevel debug = SSL_WARN);
+
+
+    /**
+     * @brief ORIGINAL (6-argument) Constructor for backward compatibility.
+     * This calls the new 7-argument constructor, passing a default buffer size of 2048.
+     */
+    explicit SSLClient( Client& client, 
+                const br_x509_trust_anchor *trust_anchors, 
+                const size_t trust_anchors_num, 
+                const int analog_pin, 
+                const size_t max_sessions = 1,
+                const DebugLevel debug = SSL_WARN)
+        // This is a "delegating constructor"
+        // It calls the main 7-argument constructor with the default buffer size
+        : SSLClient(client, trust_anchors, trust_anchors_num, analog_pin, max_sessions, 2048, debug)
+    {
+        // Body is empty, all work is done by the main constructor
+    }                       
 
     /**
      * @brief Destructor


### PR DESCRIPTION
# Description

Added the non disruptive support to change m_iobuf from a fixed-size array to a pointer and add m_iobuf_size for dynamic memory management. 

Fixes # (issue)

## Type of change

Please uncheck options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
  - [ ] I have made the appropriate changes to documentation already

# How Has This Been Tested?

I tested this code by using a custom PCB that features the W5500 and it is using Ethernet to download OTA firmware updates from Github. With the original 2048 fixed buffer the download was very slow and cut in small chunks, with the dynamic buffer, I went from 2:30 minutes download to 10 seconds. Also, I tested backward compatibility.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Device type: ESP32S2
* SSLClient version: 1.6.11
* Arduino core version: ESP32 3.3.3
* Additional library versions: Ethernet.h @ 2.0.2, ArduinoJson.h @ 7.4.2
* Hardware: W5500 Shield with this pinout:
```cpp
#define ETH_CS   33
#define ETH_SCLK 36
#define ETH_MISO 37
#define ETH_MOSI 35
#define ETH_RST  -1  // -1 if not used
```